### PR TITLE
publish package to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@observablehq/create",
   "version": "0.0.1",
+  "license": "ISC",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/observablehq/create.git"


### PR DESCRIPTION
this adds the logic to properly construct the package and deploy it to the observable github registry.  to publish, configure your **.npmrc** file with a classic github auth token with **write:packages** authority.

```
@observablehq:registry=https://npm.pkg.github.com/
//npm.pkg.github.com/:_authToken=<AUTH_TOKEN>
```

then

```
npm publish
```

when we are ready to make this package public, we will reconfigure this for npmjs.org.