### PR TITLE
yarn compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/create",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "license": "ISC",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Yarn requires that the script be named `create-<package>`. And in the case of a bare scoped package `@observablehq`, it requires the script to be named `create`. I don’t know how this works if you have multiple packages installed that are competing for the name `create` in the global path, but this is apparently required by the design of Yarn 1.x. 😞 

Ref. https://github.com/vitejs/vite/issues/1298
Ref. https://classic.yarnpkg.com/lang/en/docs/cli/create/